### PR TITLE
Automatically determine version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 EXECUTABLE=gameoflife.exe
+VERSION=$(shell git describe --tags --always --long --dirty)
 
-all: build test ## Build and run tests
+all: test build ## Build and run tests
 
 test: ## Run unit tests
 	./scripts/test_unit.sh
@@ -14,7 +15,8 @@ dep: ## Retrieve all dependencies
 build: $(EXECUTABLE) ## Build executable
 
 $(EXECUTABLE):
-	go build -i -v -o $(EXECUTABLE) ./cmd/game/main.go
+	@echo version: $(VERSION)
+	go build -i -v -o $(EXECUTABLE) -ldflags="-s -w -X main.version=$(VERSION)"  ./cmd/game/main.go
 
 clean: ## Remove previous build
 	rm $(EXECUTABLE)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ dep: ## Retrieve all dependencies
 build: $(EXECUTABLE) ## Build executable
 
 $(EXECUTABLE):
-	go build -o $(EXECUTABLE) ./cmd/game/main.go
+	go build -i -v -o $(EXECUTABLE) ./cmd/game/main.go
 
 clean: ## Remove previous build
 	rm $(EXECUTABLE)

--- a/README.md
+++ b/README.md
@@ -35,3 +35,18 @@ Conway's Game of Life is a zero player game, meaning the player sets an initial 
 - If there are exactly 3 living cells surrounding a dead cell, it will become alive, as if by reproduction.
 
 This leads to many interesting patterns and is fascinating to mess around with. Interestingly enough, it is also Turing complete, meaning it can simulate a computer. The Game of Life itself has been built with the Game of Life!
+
+## Instructions
+
+- Input
+    - Right mouse button: Add a new cell to the grid.
+    - Left mouse button: Remove an existing cell from the grid.
+    - Arrow keys: Scroll around the grid.
+    - Spacebar: Reset the scroll position to the default.
+- Menu
+    - Start/Stop: Start or stop the simulation.
+    - Store: Store current grid state in memory.
+    - Reset: Reset the grid to the state saved in memory.
+    - Clear: Clear the grid completely.
+    - Save: Save the current grid state to a file named "saved".
+    - Cells: Select the cell type to place on the grid.

--- a/cmd/game/main.go
+++ b/cmd/game/main.go
@@ -15,6 +15,8 @@ import (
 	"github.com/faiface/pixel/pixelgl"
 )
 
+var version = "v1.1.0"
+
 func main() {
 	// pixel will run on the main thread
 	pixelgl.Run(run)
@@ -40,7 +42,7 @@ func run() {
 
 	// create new window
 	cfg := pixelgl.WindowConfig{
-		Title:     "Game of Life",
+		Title:     fmt.Sprintf("Game of Life (%s)", version),
 		Icon:      []pixel.Picture{assets.Icon16x16},
 		Bounds:    pixel.R(0, 0, 1260, 960),
 		VSync:     !*disableVsync, // update at the refresh rate of the monitor

--- a/cmd/game/main.go
+++ b/cmd/game/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/eleniums/game-of-life-go/assets"
@@ -15,9 +16,11 @@ import (
 	"github.com/faiface/pixel/pixelgl"
 )
 
-var version = "v1.1.0"
+var version = "dev"
 
 func main() {
+	log.Printf("Version: %s", version)
+
 	// pixel will run on the main thread
 	pixelgl.Run(run)
 }
@@ -42,7 +45,7 @@ func run() {
 
 	// create new window
 	cfg := pixelgl.WindowConfig{
-		Title:     fmt.Sprintf("Game of Life (%s)", version),
+		Title:     fmt.Sprintf("Game of Life (%s)", strings.Split(version, "-")[0]),
 		Icon:      []pixel.Picture{assets.Icon16x16},
 		Bounds:    pixel.R(0, 0, 1260, 960),
 		VSync:     !*disableVsync, // update at the refresh rate of the monitor

--- a/cmd/game/main.go
+++ b/cmd/game/main.go
@@ -23,6 +23,7 @@ func main() {
 func run() {
 	interval := flag.Int("interval", 100, "simulation update interval in ms")
 	disableVsync := flag.Bool("disable-vsync", false, "disable vertical sync with refresh rate of monitor")
+	fps := flag.Bool("fps", false, "display frames per second")
 	pattern := flag.String("pattern", "", "name of pattern file to load as initial state (ex: -pattern ./testdata/diehard)")
 	reproduce := flag.String("reproduce", "majority-wins", "how to determine cell type when cell becomes alive (majority-wins|random-percentage)")
 	flag.Parse()
@@ -92,7 +93,9 @@ func run() {
 		frames++
 		select {
 		case <-second:
-			win.SetTitle(fmt.Sprintf("%s | FPS: %d", cfg.Title, frames))
+			if *fps {
+				win.SetTitle(fmt.Sprintf("%s | FPS: %d", cfg.Title, frames))
+			}
 			frames = 0
 		default:
 		}


### PR DESCRIPTION
- Automatically determine version.
- Run unit tests before building.
- Strip debug information from binary.
- Make frames per second an optional flag.